### PR TITLE
Dev

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+npx lint-staged
+npm run typecheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.0] - 2026-06-13
+
+### Added
+
+- Added Better Auth email authentication methods for sign up, sign in, sign out, email verification, password reset, and session lookup.
+- Added authenticated GraphQL helper support for `/graphql`.
+- Added typed auth and GraphQL request/response exports from the package root.
+- Added Node session cookie capture/replay and browser credential support for authenticated requests.
+
+### Changed
+
+- Made API key enforcement opt-in through `requireApiKey` so cookie-based auth can be used without a bearer token.
+
 ## [0.0.0-alpha.1] - 2025-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,23 +25,28 @@
 	- [🤖 Usage](#-usage)
 	- [🧪 Testing](#-testing)
 - [⚡ Quick Start](#-quick-start)
+- [🔐 Authentication](#-authentication)
+- [📡 GraphQL](#-graphql)
+- [🗂️ Project Structure](#️-project-structure)
+- [🛠️ Development](#️-development)
 - [📄 License](#-license)
 
 ---
 
 ## 📍 Overview
 
-The `@work-whiz/sdk` is a lightweight and powerful SDK designed to simplify integration with Work-Whiz services. It provides a seamless way to interact with APIs, manage workflows, and automate tasks.
+The `@work-whiz/sdk` is a lightweight TypeScript SDK for the Work Whiz API. It provides a typed client for Better Auth email authentication, authenticated GraphQL operations, and low-level HTTP requests.
 
 ---
 
 ## 👾 Features
 
-- Easy-to-use API for interacting with Work-Whiz services.
-- Built-in support for TypeScript.
-- Lightweight and fast.
-- Comprehensive error handling.
-- Regular updates and active maintenance.
+- Typed Better Auth email sign up, sign in, sign out, email verification, password reset, and session lookup.
+- Authenticated GraphQL helper for `/graphql`.
+- Automatic Better Auth session cookie capture and replay in Node.
+- Browser cookie support through Axios `withCredentials`.
+- Generic `get`, `post`, `put`, `patch`, and `delete` methods for lower-level API access.
+- TypeScript request and response types exported from the package root.
 
 ---
 
@@ -64,10 +69,14 @@ Install `@work-whiz/sdk` using npm:
 
 ### 🤖 Usage
 
-Run your project with `@work-whiz/sdk` using the following command:
+Import the client from the package root:
 
-```sh
-❯ npm start
+```typescript
+import { WorkWhizClient } from '@work-whiz/sdk';
+
+const client = new WorkWhizClient({
+  baseURL: 'http://localhost:3000',
+});
 ```
 
 ### 🧪 Testing
@@ -88,15 +97,126 @@ Here’s a quick example to get started with `@work-whiz/sdk`:
 import { WorkWhizClient } from '@work-whiz/sdk';
 
 const client = new WorkWhizClient({
-  apiKey: 'your-api-key',
+  baseURL: 'http://localhost:3000',
 });
 
 async function main() {
-  const response = await client.getData();
+  await client.signInEmail({
+    email: 'candidate@example.com',
+    password: 'AuthTest!12345',
+  });
+
+  const response = await client.graphql<{ me: { id: string; email: string } }>(
+    'query Me { me { id email } }',
+  );
+
   console.log(response);
 }
 
 main();
+```
+
+---
+
+## 🔐 Authentication
+
+The SDK maps to the Work Whiz Better Auth REST endpoints under `/api/auth`.
+
+```typescript
+await client.signUpEmail({
+  name: 'Candidate User',
+  email: 'candidate@example.com',
+  password: 'AuthTest!12345',
+  phone: '+27821234567',
+  role: 'candidate',
+  title: 'Mr',
+});
+
+await client.signInEmail({
+  email: 'candidate@example.com',
+  password: 'AuthTest!12345',
+});
+
+const session = await client.getSession();
+
+await client.signOut();
+```
+
+Available auth methods:
+
+- `signUpEmail(data)`
+- `signInEmail(data)`
+- `signOut()`
+- `verifyEmail(token)`
+- `requestPasswordReset(data)`
+- `resetPassword(data)`
+- `getSession()`
+
+In Node, the client stores the Better Auth `Set-Cookie` header from sign-in and sends it on authenticated calls. In browsers, Axios uses `withCredentials` so the browser can manage cookies.
+
+---
+
+## 📡 GraphQL
+
+Use `graphql<TData, TVariables>()` for profile and account operations exposed through `/graphql`.
+
+```typescript
+const result = await client.graphql<
+  { me: { id: string; email: string } },
+  Record<string, never>
+>('query Me { me { id email } }');
+```
+
+The GraphQL helper sends the stored Better Auth session cookie automatically when one is available.
+
+---
+
+## 🗂️ Project Structure
+
+Feature code is split by responsibility while keeping `WorkWhizClient` as the single public entrypoint.
+
+```text
+src/
+  config/
+    client.ts
+    index.ts
+  graphql/
+    graphql.resource.ts
+    graphql.types.ts
+    index.ts
+  interfaces/
+    client.ts
+    index.ts
+  modules/
+    auth/
+      auth.resource.ts
+      auth.types.ts
+      index.ts
+  index.ts
+```
+
+`src/config/client.ts` owns Axios setup, API key handling, generic HTTP methods, and session cookie state. Auth behavior lives in `src/modules/auth`, and GraphQL behavior lives in `src/graphql`.
+
+---
+
+## 🛠️ Development
+
+Run tests:
+
+```sh
+npm test
+```
+
+Build the package:
+
+```sh
+npm run build
+```
+
+Run lint:
+
+```sh
+npm run lint
 ```
 
 --- 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^22.14.1",
         "eslint": "^9.25.0",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
+        "lint-staged": "^17.0.7",
         "prettier": "^3.5.3",
         "rollup": "^2.79.2",
         "rollup-plugin-terser": "^7.0.2",
@@ -2243,6 +2245,85 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2521,6 +2602,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2774,6 +2868,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -3080,6 +3181,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3278,6 +3392,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {
@@ -4293,6 +4423,138 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
+      "integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4322,6 +4584,160 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4458,6 +4874,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -4991,6 +5420,52 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5001,6 +5476,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "2.79.2",
@@ -5162,6 +5644,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5211,6 +5739,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {
@@ -5357,6 +5895,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tmpl": {
@@ -5701,6 +6249,23 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,23 @@
 {
   "name": "@work-whiz/sdk",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@work-whiz/sdk",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.9.0",
-        "dotenv": "^16.5.0",
         "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-typescript": "^12.1.2",
-        "@types/dotenv": "^6.1.1",
         "@types/jest": "^29.5.14",
-        "@types/node": "^22.14.1",
+        "@types/node": "^22.19.21",
         "eslint": "^9.25.0",
         "jest": "^29.7.0",
         "prettier": "^3.5.3",
@@ -1470,16 +1468,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/dotenv": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
-      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -1543,9 +1531,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2450,18 +2438,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
     "test:coverage": "jest --coverage",
     "prepublish": "npm run build",
     "lint": "eslint src --ext .ts",
-    "format": "prettier --write src/**/*.ts"
+    "format": "prettier --write src/**/*.ts",
+    "prepare": "husky",
+    "typecheck": "tsc --noEmit"
+  },
+  "lint-staged": {
+    "*.{js,ts,tsx}": [
+      "eslint --fix"
+    ]
   },
   "keywords": [
     "work-whiz",
@@ -51,7 +58,9 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.14.1",
     "eslint": "^9.25.0",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
+    "lint-staged": "^17.0.7",
     "prettier": "^3.5.3",
     "rollup": "^2.79.2",
     "rollup-plugin-terser": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@work-whiz/sdk",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Official SDK for Work Whiz API",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "browser": "dist/index.umd.js",
+  "browser": "dist/index.esm.js",
+  "react-native": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rollup -c",
+    "build:watch": "rollup -c --watch",
+    "dev": "npm run build:watch",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "prepublish": "npm run build",
@@ -40,16 +43,14 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.9.0",
-    "dotenv": "^16.5.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
-    "@types/dotenv": "^6.1.1",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.14.1",
+    "@types/node": "^22.19.21",
     "eslint": "^9.25.0",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,10 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
 
+const externalDependencies = ['axios', 'tslib'];
+const isExternalDependency = id =>
+  externalDependencies.some(pkg => id === pkg || id.startsWith(`${pkg}/`));
+
 export default {
   input: 'src/index.ts',
   output: [
@@ -10,7 +14,7 @@ export default {
       file: 'dist/index.cjs.js',
       format: 'cjs',
       sourcemap: true,
-      exports: 'auto',
+      exports: 'named',
     },
     {
       file: 'dist/index.esm.js',
@@ -22,9 +26,9 @@ export default {
       format: 'umd',
       name: 'WorkWhizSDK',
       sourcemap: true,
+      exports: 'named',
       globals: {
         axios: 'axios',
-        dotenv: 'dotenv',
         tslib: 'tslib',
       },
     },
@@ -37,5 +41,5 @@ export default {
     }),
     terser(),
   ],
-  external: ['axios', 'dotenv', 'tslib'],
+  external: isExternalDependency,
 };

--- a/src/config/client.spec.ts
+++ b/src/config/client.spec.ts
@@ -1,19 +1,49 @@
 import { WorkWhizClient } from './client';
+import axios, { AxiosInstance } from 'axios';
+
+jest.mock('axios');
+
+const mockedAxios = jest.mocked(axios);
+
+const createMockAxiosInstance = () =>
+  ({
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  }) as unknown as jest.Mocked<AxiosInstance>;
 
 describe('WorkWhizClient', () => {
   const originalEnv = process.env;
+  let axiosInstance: jest.Mocked<AxiosInstance>;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    axiosInstance = createMockAxiosInstance();
+    mockedAxios.create.mockReturnValue(axiosInstance);
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    jest.restoreAllMocks();
   });
 
-  it('should throw an error if API key is missing', () => {
+  it('should create an auth-capable instance without an API key', () => {
     delete process.env.WORK_WHIZ_API_KEY;
-    expect(() => new WorkWhizClient({})).toThrow(
+    const client = new WorkWhizClient({});
+    expect(client).toBeDefined();
+  });
+
+  it('should throw an error if API key is missing when explicitly required', () => {
+    delete process.env.WORK_WHIZ_API_KEY;
+    expect(() => new WorkWhizClient({ requireApiKey: true })).toThrow(
       'API key is required to initialize WorkWhizClient.',
     );
   });
@@ -27,5 +57,217 @@ describe('WorkWhizClient', () => {
     process.env.WORK_WHIZ_API_KEY = 'env-test-key';
     const client = new WorkWhizClient({});
     expect(client).toBeDefined();
+  });
+
+  it('should sign in with email and store the Better Auth session cookie', async () => {
+    axiosInstance.post.mockResolvedValueOnce({
+      data: {
+        user: { id: 'user-1', email: 'candidate@example.com' },
+      },
+      headers: {
+        'set-cookie': [
+          'better-auth.session_token=session-value; Path=/; HttpOnly',
+          'better-auth.csrf_token=csrf-value; Path=/',
+        ],
+      },
+    });
+    const client = new WorkWhizClient({});
+
+    const response = await client.signInEmail({
+      email: 'candidate@example.com',
+      password: 'AuthTest!12345',
+    });
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      '/api/auth/sign-in/email',
+      {
+        email: 'candidate@example.com',
+        password: 'AuthTest!12345',
+      },
+      undefined,
+    );
+    expect(response.user?.email).toBe('candidate@example.com');
+  });
+
+  it('should sign up with email using the documented Better Auth endpoint', async () => {
+    axiosInstance.post.mockResolvedValueOnce({
+      data: { user: { id: 'user-1', email: 'candidate@example.com' } },
+      headers: {},
+    });
+    const client = new WorkWhizClient({});
+
+    await client.signUpEmail({
+      name: 'Candidate User',
+      email: 'candidate@example.com',
+      password: 'AuthTest!12345',
+      phone: '+27821234567',
+      role: 'candidate',
+      title: 'Mr',
+    });
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      '/api/auth/sign-up/email',
+      {
+        name: 'Candidate User',
+        email: 'candidate@example.com',
+        password: 'AuthTest!12345',
+        phone: '+27821234567',
+        role: 'candidate',
+        title: 'Mr',
+      },
+      undefined,
+    );
+  });
+
+  it('should verify email with the token query parameter', async () => {
+    axiosInstance.get.mockResolvedValueOnce({
+      data: { message: 'Email verified.' },
+      headers: {},
+    });
+    const client = new WorkWhizClient({});
+
+    await client.verifyEmail('verification-token');
+
+    expect(axiosInstance.get).toHaveBeenCalledWith('/api/auth/verify-email', {
+      params: {
+        token: 'verification-token',
+      },
+    });
+  });
+
+  it('should request and reset passwords through the documented auth endpoints', async () => {
+    axiosInstance.post
+      .mockResolvedValueOnce({
+        data: { message: 'Password reset email requested.' },
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        data: { message: 'Password reset successfully.' },
+        headers: {},
+      });
+    const client = new WorkWhizClient({});
+
+    await client.requestPasswordReset({
+      email: 'candidate@example.com',
+      redirectTo: 'http://localhost:4200/reset-password',
+    });
+    await client.resetPassword({
+      token: 'reset-token',
+      newPassword: 'AuthTest!67890',
+    });
+
+    expect(axiosInstance.post).toHaveBeenNthCalledWith(
+      1,
+      '/api/auth/request-password-reset',
+      {
+        email: 'candidate@example.com',
+        redirectTo: 'http://localhost:4200/reset-password',
+      },
+      undefined,
+    );
+    expect(axiosInstance.post).toHaveBeenNthCalledWith(
+      2,
+      '/api/auth/reset-password',
+      {
+        token: 'reset-token',
+        newPassword: 'AuthTest!67890',
+      },
+      undefined,
+    );
+  });
+
+  it('should send the stored Better Auth cookie when getting the current session', async () => {
+    axiosInstance.post.mockResolvedValueOnce({
+      data: {
+        user: { id: 'user-1', email: 'candidate@example.com' },
+      },
+      headers: {
+        'set-cookie': ['better-auth.session_token=session-value; Path=/'],
+      },
+    });
+    axiosInstance.get.mockResolvedValueOnce({
+      data: {
+        user: { id: 'user-1', email: 'candidate@example.com' },
+      },
+      headers: {},
+    });
+    const client = new WorkWhizClient({});
+
+    await client.signInEmail({
+      email: 'candidate@example.com',
+      password: 'AuthTest!12345',
+    });
+    await client.getSession();
+
+    expect(axiosInstance.get).toHaveBeenCalledWith('/api/auth/get-session', {
+      headers: {
+        Cookie: 'better-auth.session_token=session-value',
+      },
+    });
+  });
+
+  it('should send the stored Better Auth cookie when signing out', async () => {
+    axiosInstance.post
+      .mockResolvedValueOnce({
+        data: { user: { id: 'user-1' } },
+        headers: {
+          'set-cookie': ['better-auth.session_token=session-value; Path=/'],
+        },
+      })
+      .mockResolvedValueOnce({ data: { message: 'Signed out.' }, headers: {} });
+    const client = new WorkWhizClient({});
+
+    await client.signInEmail({
+      email: 'candidate@example.com',
+      password: 'AuthTest!12345',
+    });
+    await client.signOut();
+
+    expect(axiosInstance.post).toHaveBeenLastCalledWith(
+      '/api/auth/sign-out',
+      {},
+      {
+        headers: {
+          Cookie: 'better-auth.session_token=session-value',
+        },
+      },
+    );
+  });
+
+  it('should post GraphQL operations with the stored Better Auth cookie', async () => {
+    axiosInstance.post
+      .mockResolvedValueOnce({
+        data: { user: { id: 'user-1' } },
+        headers: {
+          'set-cookie': ['better-auth.session_token=session-value; Path=/'],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { data: { me: { id: 'user-1' } } },
+        headers: {},
+      });
+    const client = new WorkWhizClient({});
+
+    await client.signInEmail({
+      email: 'candidate@example.com',
+      password: 'AuthTest!12345',
+    });
+    const response = await client.graphql<{ me: { id: string } }>(
+      'query Me { me { id } }',
+    );
+
+    expect(axiosInstance.post).toHaveBeenLastCalledWith(
+      '/graphql',
+      {
+        query: 'query Me { me { id } }',
+        variables: undefined,
+      },
+      {
+        headers: {
+          Cookie: 'better-auth.session_token=session-value',
+        },
+      },
+    );
+    expect(response.data?.me.id).toBe('user-1');
   });
 });

--- a/src/config/client.ts
+++ b/src/config/client.ts
@@ -4,10 +4,27 @@ import axios, {
   AxiosResponse,
   AxiosError,
 } from 'axios';
-import dotenv from 'dotenv';
+import { AuthResource } from '../modules/auth';
+import {
+  AuthResponse,
+  AuthSessionResponse,
+  MessageResponse,
+  RequestPasswordResetRequest,
+  ResetPasswordRequest,
+  SignInEmailRequest,
+  SignUpEmailRequest,
+} from '../modules/auth/auth.types';
+import { GraphQLResource } from '../graphql';
+import { GraphQLResponse } from '../graphql/graphql.types';
 import { ClientConfig, IWorkWhizClient } from '../interfaces/client';
 
-dotenv.config();
+const getEnv = (key: string): string | undefined => {
+  if (typeof process === 'undefined') {
+    return undefined;
+  }
+
+  return process.env?.[key];
+};
 
 class ApiError extends Error {
   constructor(
@@ -24,10 +41,13 @@ class ApiError extends Error {
 export class WorkWhizClient implements IWorkWhizClient {
   private instance: AxiosInstance;
   private apiKey: string;
+  private sessionCookie?: string;
+  private auth: AuthResource;
+  private graphQL: GraphQLResource;
 
   constructor(config: ClientConfig) {
-    this.apiKey = config.apiKey || process.env.WORK_WHIZ_API_KEY || '';
-    if (!this.apiKey) {
+    this.apiKey = config.apiKey || getEnv('WORK_WHIZ_API_KEY') || '';
+    if (config.requireApiKey && !this.apiKey) {
       console.error(
         '❌ [Error]: API key is required to initialize WorkWhizClient.',
       );
@@ -37,16 +57,15 @@ export class WorkWhizClient implements IWorkWhizClient {
     console.info('🚀 [Info]: Initializing WorkWhizClient...');
     this.instance = axios.create({
       baseURL:
-        config.baseURL ||
-        process.env.WORK_WHIZ_BASE_URL ||
-        'https://api.workwhiz.com',
+        config.baseURL || getEnv('WORK_WHIZ_BASE_URL') || 'https://api.workwhiz.com',
       timeout: config.timeout
         ? Number(config.timeout)
-        : Number(process.env.WORK_WHIZ_TIMEOUT) || 5000,
+        : Number(getEnv('WORK_WHIZ_TIMEOUT')) || 5000,
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },
+      withCredentials: true,
     });
 
     this.instance.interceptors.request.use(req => {
@@ -54,7 +73,9 @@ export class WorkWhizClient implements IWorkWhizClient {
         `📤 [Request]: Sending ${req.method?.toUpperCase()} request to ${req.url}`,
       );
       req.headers = req.headers || {};
-      req.headers.Authorization = `Bearer ${this.apiKey}`;
+      if (this.apiKey) {
+        req.headers.Authorization = `Bearer ${this.apiKey}`;
+      }
       return req;
     });
 
@@ -80,6 +101,50 @@ export class WorkWhizClient implements IWorkWhizClient {
         throw new ApiError(error.message || 'Network error', undefined);
       },
     );
+
+    this.auth = new AuthResource({
+      http: this.instance,
+      storeSessionCookie: headers => this.storeSessionCookie(headers),
+      clearSessionCookie: () => this.clearSessionCookie(),
+      withSessionCookie: config => this.withSessionCookie(config),
+    });
+    this.graphQL = new GraphQLResource({
+      http: this.instance,
+      withSessionCookie: config => this.withSessionCookie(config),
+    });
+  }
+
+  private storeSessionCookie(headers?: Record<string, any>): void {
+    const setCookie = headers?.['set-cookie'] || headers?.['Set-Cookie'];
+    if (!setCookie) {
+      return;
+    }
+
+    const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+    this.sessionCookie = cookies
+      .map(cookie => String(cookie).split(';')[0])
+      .filter(Boolean)
+      .join('; ');
+  }
+
+  private clearSessionCookie(): void {
+    this.sessionCookie = undefined;
+  }
+
+  private withSessionCookie(
+    config?: AxiosRequestConfig<any>,
+  ): AxiosRequestConfig<any> {
+    if (!this.sessionCookie) {
+      return config || {};
+    }
+
+    return {
+      ...config,
+      headers: {
+        ...config?.headers,
+        Cookie: this.sessionCookie,
+      },
+    };
   }
 
   public get = async <T>(
@@ -139,5 +204,63 @@ export class WorkWhizClient implements IWorkWhizClient {
       `✅ [Success]: DELETE request to ${url} completed successfully.`,
     );
     return response.data;
+  };
+
+  public signUpEmail = async (
+    data: SignUpEmailRequest,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<AuthResponse> => {
+    return this.auth.signUpEmail(data, config);
+  };
+
+  public signInEmail = async (
+    data: SignInEmailRequest,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<AuthResponse> => {
+    return this.auth.signInEmail(data, config);
+  };
+
+  public signOut = async (
+    config?: AxiosRequestConfig<any>,
+  ): Promise<MessageResponse> => {
+    return this.auth.signOut(config);
+  };
+
+  public verifyEmail = async (
+    token: string,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<MessageResponse> => {
+    return this.auth.verifyEmail(token, config);
+  };
+
+  public requestPasswordReset = async (
+    data: RequestPasswordResetRequest,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<MessageResponse> => {
+    return this.auth.requestPasswordReset(data, config);
+  };
+
+  public resetPassword = async (
+    data: ResetPasswordRequest,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<MessageResponse> => {
+    return this.auth.resetPassword(data, config);
+  };
+
+  public getSession = async (
+    config?: AxiosRequestConfig<any>,
+  ): Promise<AuthSessionResponse> => {
+    return this.auth.getSession(config);
+  };
+
+  public graphql = async <
+    TData = unknown,
+    TVariables extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    query: string,
+    variables?: TVariables,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<GraphQLResponse<TData>> => {
+    return this.graphQL.graphql(query, variables, config);
   };
 }

--- a/src/graphql/graphql.resource.ts
+++ b/src/graphql/graphql.resource.ts
@@ -1,0 +1,29 @@
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { GraphQLResponse } from './graphql.types';
+
+interface GraphQLResourceDependencies {
+  http: AxiosInstance;
+  withSessionCookie: (
+    config?: AxiosRequestConfig<any>,
+  ) => AxiosRequestConfig<any>;
+}
+
+export class GraphQLResource {
+  constructor(private readonly dependencies: GraphQLResourceDependencies) {}
+
+  public graphql = async <
+    TData = unknown,
+    TVariables extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    query: string,
+    variables?: TVariables,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<GraphQLResponse<TData>> => {
+    const response = await this.dependencies.http.post<GraphQLResponse<TData>>(
+      '/graphql',
+      { query, variables },
+      this.dependencies.withSessionCookie(config),
+    );
+    return response.data;
+  };
+}

--- a/src/graphql/graphql.types.ts
+++ b/src/graphql/graphql.types.ts
@@ -1,0 +1,7 @@
+export interface GraphQLResponse<TData = unknown> {
+  data?: TData | null;
+  errors?: Array<{
+    message: string;
+    extensions?: Record<string, unknown>;
+  }>;
+}

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,0 +1,2 @@
+export { GraphQLResource } from './graphql.resource';
+export * from './graphql.types';

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,36 @@
+import WorkWhizSDK, { WorkWhizClient } from './index';
+
+jest.mock('axios', () => ({
+  create: jest.fn(() => ({
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  })),
+}));
+
+describe('package entrypoint', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should export WorkWhizClient from the package root', () => {
+    expect(new WorkWhizClient({})).toBeInstanceOf(WorkWhizClient);
+  });
+
+  it('should expose client methods from the default SDK export', () => {
+    const sdk = new WorkWhizSDK({});
+
+    expect(typeof sdk.signInEmail).toBe('function');
+    expect(typeof sdk.graphql).toBe('function');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
-import 'dotenv/config';
 import { WorkWhizClient } from './config/client';
 import { ClientConfig } from './interfaces/client';
 
-class WorkWhizSDK {
+class WorkWhizSDK extends WorkWhizClient {
   constructor(config: ClientConfig = {}) {
-    const client = new WorkWhizClient(config);
+    super(config);
   }
 }
 
+export { WorkWhizClient } from './config/client';
+export * from './interfaces';
 export default WorkWhizSDK;

--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -1,9 +1,20 @@
 import { AxiosRequestConfig } from 'axios';
+import {
+  AuthResponse,
+  AuthSessionResponse,
+  MessageResponse,
+  RequestPasswordResetRequest,
+  ResetPasswordRequest,
+  SignInEmailRequest,
+  SignUpEmailRequest,
+} from '../modules/auth';
+import { GraphQLResponse } from '../graphql';
 
 export interface ClientConfig {
   baseURL?: string;
   apiKey?: string;
   timeout?: string;
+  requireApiKey?: boolean;
 }
 
 export interface ApiError {
@@ -21,4 +32,34 @@ export interface IWorkWhizClient {
     config?: AxiosRequestConfig,
   ) => Promise<T>;
   delete: <T>(url: string, config?: AxiosRequestConfig) => Promise<T>;
+  signUpEmail: (
+    data: SignUpEmailRequest,
+    config?: AxiosRequestConfig,
+  ) => Promise<AuthResponse>;
+  signInEmail: (
+    data: SignInEmailRequest,
+    config?: AxiosRequestConfig,
+  ) => Promise<AuthResponse>;
+  signOut: (config?: AxiosRequestConfig) => Promise<MessageResponse>;
+  verifyEmail: (
+    token: string,
+    config?: AxiosRequestConfig,
+  ) => Promise<MessageResponse>;
+  requestPasswordReset: (
+    data: RequestPasswordResetRequest,
+    config?: AxiosRequestConfig,
+  ) => Promise<MessageResponse>;
+  resetPassword: (
+    data: ResetPasswordRequest,
+    config?: AxiosRequestConfig,
+  ) => Promise<MessageResponse>;
+  getSession: (config?: AxiosRequestConfig) => Promise<AuthSessionResponse>;
+  graphql: <
+    TData = unknown,
+    TVariables extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    query: string,
+    variables?: TVariables,
+    config?: AxiosRequestConfig,
+  ) => Promise<GraphQLResponse<TData>>;
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,1 +1,3 @@
-export { ClientConfig, IWorkWhizClient } from './client';
+export { ApiError, ClientConfig, IWorkWhizClient } from './client';
+export * from '../modules/auth';
+export * from '../graphql';

--- a/src/modules/auth/auth.resource.ts
+++ b/src/modules/auth/auth.resource.ts
@@ -1,0 +1,112 @@
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
+import {
+  AuthResponse,
+  AuthSessionResponse,
+  MessageResponse,
+  RequestPasswordResetRequest,
+  ResetPasswordRequest,
+  SignInEmailRequest,
+  SignUpEmailRequest,
+} from './auth.types';
+
+interface AuthResourceDependencies {
+  http: AxiosInstance;
+  storeSessionCookie: (headers?: Record<string, any>) => void;
+  clearSessionCookie: () => void;
+  withSessionCookie: (
+    config?: AxiosRequestConfig<any>,
+  ) => AxiosRequestConfig<any>;
+}
+
+export class AuthResource {
+  constructor(private readonly dependencies: AuthResourceDependencies) {}
+
+  public signUpEmail = async (
+    data: SignUpEmailRequest,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<AuthResponse> => {
+    const response = await this.dependencies.http.post<AuthResponse>(
+      '/api/auth/sign-up/email',
+      data,
+      config,
+    );
+    this.dependencies.storeSessionCookie(response.headers);
+    return response.data;
+  };
+
+  public signInEmail = async (
+    data: SignInEmailRequest,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<AuthResponse> => {
+    const response = await this.dependencies.http.post<AuthResponse>(
+      '/api/auth/sign-in/email',
+      data,
+      config,
+    );
+    this.dependencies.storeSessionCookie(response.headers);
+    return response.data;
+  };
+
+  public signOut = async (
+    config?: AxiosRequestConfig<any>,
+  ): Promise<MessageResponse> => {
+    const response = await this.dependencies.http.post<MessageResponse>(
+      '/api/auth/sign-out',
+      {},
+      this.dependencies.withSessionCookie(config),
+    );
+    this.dependencies.clearSessionCookie();
+    return response.data;
+  };
+
+  public verifyEmail = async (
+    token: string,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<MessageResponse> => {
+    const response = await this.dependencies.http.get<MessageResponse>(
+      '/api/auth/verify-email',
+      {
+        ...config,
+        params: {
+          ...config?.params,
+          token,
+        },
+      },
+    );
+    return response.data;
+  };
+
+  public requestPasswordReset = async (
+    data: RequestPasswordResetRequest,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<MessageResponse> => {
+    const response = await this.dependencies.http.post<MessageResponse>(
+      '/api/auth/request-password-reset',
+      data,
+      config,
+    );
+    return response.data;
+  };
+
+  public resetPassword = async (
+    data: ResetPasswordRequest,
+    config?: AxiosRequestConfig<any>,
+  ): Promise<MessageResponse> => {
+    const response = await this.dependencies.http.post<MessageResponse>(
+      '/api/auth/reset-password',
+      data,
+      config,
+    );
+    return response.data;
+  };
+
+  public getSession = async (
+    config?: AxiosRequestConfig<any>,
+  ): Promise<AuthSessionResponse> => {
+    const response = await this.dependencies.http.get<AuthSessionResponse>(
+      '/api/auth/get-session',
+      this.dependencies.withSessionCookie(config),
+    );
+    return response.data;
+  };
+}

--- a/src/modules/auth/auth.types.ts
+++ b/src/modules/auth/auth.types.ts
@@ -1,0 +1,55 @@
+export type WorkWhizRole = 'candidate' | 'employer' | 'admin';
+
+export interface AuthUser {
+  id: string;
+  name?: string;
+  email: string;
+  phone?: string;
+  role?: WorkWhizRole;
+  emailVerified?: boolean;
+  isVerified?: boolean;
+  isActive?: boolean;
+  isLocked?: boolean;
+}
+
+export interface SignUpEmailRequest {
+  name: string;
+  email: string;
+  password: string;
+  phone: string;
+  role: 'candidate' | 'employer';
+  title?: string;
+  industry?: string;
+  websiteUrl?: string;
+  location?: string;
+  description?: string;
+  size?: number;
+  foundedIn?: number;
+}
+
+export interface SignInEmailRequest {
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  user?: AuthUser;
+  [key: string]: any;
+}
+
+export interface RequestPasswordResetRequest {
+  email: string;
+  redirectTo?: string;
+}
+
+export interface ResetPasswordRequest {
+  token: string;
+  newPassword: string;
+}
+
+export interface MessageResponse {
+  message?: string;
+  [key: string]: any;
+}
+
+export type AuthSessionResponse = AuthResponse | null;

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,0 +1,2 @@
+export { AuthResource } from './auth.resource';
+export * from './auth.types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "declaration": true,
     "baseUrl": "./",
     "paths": {
       "*": ["node_modules/*"]
@@ -14,5 +15,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce first stable auth-focused SDK version with Better Auth email flows, cookie-based session handling, and authenticated GraphQL support, while tightening packaging and build configuration.

New Features:
- Expose Better Auth email authentication methods (sign up, sign in, sign out, email verification, password reset, and session lookup) on the WorkWhiz client.
- Add a typed GraphQL helper on the client for issuing authenticated operations to the `/graphql` endpoint.
- Export typed auth and GraphQL request/response interfaces from the package root for consumer typing.

Enhancements:
- Refine client configuration to make API key enforcement optional via `requireApiKey`, allowing cookie-based auth without a bearer token.
- Add automatic Better Auth session cookie capture and replay in Node, and enable browser credential handling via Axios `withCredentials`.
- Refactor internal auth and GraphQL logic into dedicated resource modules while keeping `WorkWhizClient` as the single entrypoint.
- Improve environment handling by removing dotenv dependency and reading env vars defensively via a helper, making the SDK more browser-friendly.
- Update README with concrete auth, GraphQL, and usage examples plus project structure and development instructions.
- Adjust Rollup config and TypeScript settings (declaration output, externals, export style) to better support different runtimes and bundlers.
- Expose `ApiError` through interfaces and simplify the SDK default export to extend `WorkWhizClient`.

Build:
- Bump package version to 0.1.0 and align `main`, `module`, `browser`, and `react-native` entry points.
- Add dev-time scripts for watch builds, type-checking, and lint/format integration, and configure externals in Rollup via a helper.

CI:
- Introduce Husky and lint-staged configuration to run ESLint on staged files before commits.

Documentation:
- Rewrite README feature list and quick start to focus on auth, GraphQL, and low-level HTTP usage, and document project structure, auth API surface, and development commands.

Tests:
- Expand client tests to cover auth flows, session cookie propagation, and GraphQL calls using a mocked Axios instance.

Chores:
- Update changelog with a 0.1.0 release entry describing the new authentication and GraphQL capabilities.